### PR TITLE
Fix for wrong arity of callback function for c-ares

### DIFF
--- a/helper.c
+++ b/helper.c
@@ -262,7 +262,7 @@ static const unsigned char *skip_query(const unsigned char *aptr, const unsigned
 	return aptr;
 }
 
-static void cares_callback(void *arg, int status, unsigned char *abuf, int alen) {
+static void cares_callback(void *arg, int status, int timeouts, unsigned char *abuf, int alen) {
 	int i;
 	unsigned int ancount, nscount, arcount;
 	const unsigned char *aptr;


### PR DESCRIPTION
A few years ago (since 2007, see this commit - bagder/c-ares@50ba81cd230f9054fa7c45cb4202ce8720c502b3  ) C-Ares changed the arity of a ares_callback function type. We have to change cares_callback function acordingly. 

See rhbz #753372 for further details:

https://bugzilla.redhat.com/753372

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
