### PR TITLE
Fix inline function usage

### DIFF
--- a/header_f.c
+++ b/header_f.c
@@ -620,7 +620,7 @@ void print_message_line(char *message)
 }
 
 /* return pointer to the beginning of the message body */
-inline char* get_body(char *mes) {
+char* get_body(char *mes) {
 	char *cr;
 
 	if ((cr = strstr(mes, "\r\n\r\n")) != NULL) {

--- a/header_f.h
+++ b/header_f.h
@@ -61,5 +61,5 @@ void new_transaction(char *message, char *reply);
 
 void print_message_line(char *message);
 
-inline char* get_body(char *mes);
+char* get_body(char *mes);
 #endif

--- a/helper.c
+++ b/helper.c
@@ -303,7 +303,7 @@ static void cares_callback(void *arg, int status, int timeouts, unsigned char *a
 	}
 }
 
-inline unsigned long srv_ares(char *host, int *port, char *srv) {
+static inline unsigned long srv_ares(char *host, int *port, char *srv) {
 	int nfds, count, srvh_len;
 	char *srvh;
 	fd_set read_fds, write_fds;
@@ -356,7 +356,7 @@ inline unsigned long srv_ares(char *host, int *port, char *srv) {
 #endif // HAVE_CARES_H
 
 #ifdef HAVE_RULI_H
-inline unsigned long srv_ruli(char *host, int *port, char *srv) {
+static inline unsigned long srv_ruli(char *host, int *port, char *srv) {
 	int srv_code;
 	int ruli_opts = RULI_RES_OPT_SEARCH | RULI_RES_OPT_SRV_NOINET6 | RULI_RES_OPT_SRV_NOSORT6 | RULI_RES_OPT_SRV_NOFALL;
 #ifdef RULI_RES_OPT_SRV_CNAME

--- a/shoot.c
+++ b/shoot.c
@@ -71,7 +71,7 @@ struct sipsak_delay delays;
  * reply matching is enabled and no match occured
  */
 
-inline static void on_success(char *rep)
+static inline void on_success(char *rep)
 {
 	if ((rep != NULL) && re && regexec(re, rep, 0, 0, 0) == REG_NOMATCH) {
 		log_message(req);


### PR DESCRIPTION
The semantics for inline functions are sometimes incompatible between
GNU C and C11. With recent GCCs the default standard has changed so
the code fails to build now.

Unify all file scope inline functions to be «static inline», and remove
the inline keyword for previously external inline functions.