### PR TITLE
Use top_srcdir instead of top_builddir

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,6 +2,6 @@ TESTS = check_helper
 
 check_PROGRAMS = check_helper
 
-check_helper_SOURCES = check_helper.c $(top_builddir)/helper.h $(top_builddir)/helper.c $(top_builddir)/exit_code.h $(top_builddir)/exit_code.c
+check_helper_SOURCES = check_helper.c $(top_srcdir)/helper.h $(top_srcdir)/helper.c $(top_srcdir)/exit_code.h $(top_srcdir)/exit_code.c
 check_helper_CFLAGS = @CHECK_CFLAGS@ -DRUNNING_CHECK
 check_helper_LDADD = @CHECK_LIBS@


### PR DESCRIPTION
The sources are always in the srcdir not builddir. This fixes out of
tree builds («mkdir build-tree; cd build-tree; ../configure; make»).