### PR TITLE
Make it possible to disable raw socket support

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -23,6 +23,27 @@ AC_DEFUN([SIPSAK_ICMP],
 	]])
 ])
 
+AC_DEFUN([SIPSAK_RAW_SUPPORT],
+[
+	AC_REQUIRE([SIPSAK_IP_UDP])
+	AC_REQUIRE([SIPSAK_ICMP])
+	AC_CHECK_HEADERS([cygwin/icmp.h])
+	AC_ARG_ENABLE([raw-support],
+	  AS_HELP_STRING([--disable-raw-support], [compile without raw socket support]),
+	  [sipsak_raw_support=$enable_raw_support],
+	  [sipsak_raw_support=yes])
+	AC_MSG_CHECKING([raw socket support])
+	AS_IF([test "X$ac_cv_header_netinet_ip_h" = "Xno" ||
+	       test "X$ac_cv_header_netinet_ip_icmp_h" = "Xno" ||
+	       test "X$ac_cv_header_cygwin_icmp_h" = "Xyes"], [
+	  sipsak_raw_support=no
+	])
+	AS_IF([test "X$sipsak_raw_support" = "Xyes"], [
+	  AC_DEFINE([RAW_SUPPORT], [1], [Define to 1 to use raw socket support])
+	])
+	AC_MSG_RESULT([$sipsak_raw_support])
+])
+
 AC_DEFUN([SIPSAK_TIMER],
 [
 	# Check for T1 timer value

--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ AC_HEADER_TIME
 
 SIPSAK_IP_UDP
 SIPSAK_ICMP
-AC_CHECK_HEADERS([cygwin/icmp.h],,,)
+SIPSAK_RAW_SUPPORT
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_SIZE_T

--- a/shoot.h
+++ b/shoot.h
@@ -24,16 +24,6 @@
 # include "config.h"
 #endif
 
-#ifdef HAVE_NETINET_IP_H
-# ifdef HAVE_NETINET_IP_ICMP_H
-#  ifdef HAVE_NETINET_UDP_H
-#   ifndef HAVE_CYGWIN_ICMP_H
-#    define RAW_SUPPORT
-#   endif
-#  endif
-# endif
-#endif
-
 #define LPORT_STR_LEN 6
 
 struct sipsak_regexp {


### PR DESCRIPTION
Sipsak opens a raw socket to listen to (any and all) ICMP messages.
Every time an ICMP packet is received, the respective loop branch runs
to read/parse the ICMP packet. This branch doesn't check for timeouts
and won't terminate the loop. If no actual UDP response is ever received,
and if there's enough ICMP traffic on the network so that select() never
runs into a timeout, sipsak will continue to run forever and won't honour
the requested timeout.

Fixes #3.