### PR TITLE
Fix autotools usage

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -97,24 +97,12 @@ AC_DEFUN([SIPSAK_DBG_PRINT],
 
 AC_DEFUN([CHECK_PROG_DISTCC],
 [
-    AC_MSG_CHECKING([for distcc])
+    AC_MSG_CHECKING([whether to use distcc])
     AC_ARG_ENABLE([distcc],
         AC_HELP_STRING([--enable-distcc], [compile in parallel with distcc]),
         [
-			distcc_dirs="/ /usr /usr/local /usr/local/gnu /usr/gnu /opt /opt/local"
-            for dir in $distcc_dirs; do
-                if test -x "$dir/bin/distcc"; then
-                    found_distcc=yes;
-                    DISTCC="$dir/bin/distcc"
-                    break;
-                fi
-            done
-            if test x_$found_distcc != x_yes; then
-                AC_MSG_ERROR([not found])
-            else
-                AC_MSG_RESULT([yes])
-                AC_SUBST([DISTCC])
-            fi
+          AC_MSG_RESULT([yes])
+          AC_CHECK_PROG([DISTCC], [distcc])
         ],
         [ AC_MSG_RESULT([not requested])
         ])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -135,7 +135,7 @@ AC_DEFUN([SIPSAK_GCC_STACK_PROTECT_CC],[
     ssp_old_cflags="$CFLAGS"
     CFLAGS="$CFLAGS -fstack-protector"
     AC_COMPILE_IFELSE(,,, ssp_cc=no)
-    echo $ssp_cc
+    AC_MSG_RESULT([$ssp_cc])
     if test "X$ssp_cc" = "Xno"; then
       CFLAGS="$ssp_old_cflags"
     else

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -60,7 +60,7 @@ AC_DEFUN([SIPSAK_OLD_FQDN],
 [
     AC_MSG_CHECKING([oldstyle numeric])
     AC_ARG_ENABLE([ips],
-       AC_HELP_STRING([--disbale-ips], [compile with oldstyle --numeric behavior]),
+       AS_HELP_STRING([--disbale-ips], [compile with oldstyle --numeric behavior]),
        [
         AC_MSG_RESULT([yes])
         AC_DEFINE([OLDSTYLE_FQDN], [1], [Oldstyle FQDN behavior])
@@ -73,7 +73,7 @@ AC_DEFUN([SIPSAK_TLS],
 [
     AC_MSG_CHECKING([disable TLS])
     AC_ARG_ENABLE([tls],
-       AC_HELP_STRING([--disable-tls], [compile without TLS transport]),
+       AS_HELP_STRING([--disable-tls], [compile without TLS transport]),
        [
         AC_MSG_RESULT([yes])
         AC_DEFINE([SIPSAK_NO_TLS], [1], [Skip TLS transport])
@@ -86,7 +86,7 @@ AC_DEFUN([SIPSAK_DBG_PRINT],
 [
     AC_MSG_CHECKING([enable debug messages])
     AC_ARG_ENABLE([debug],
-       AC_HELP_STRING([--enable-debug], [compile extra debug messages]),
+       AS_HELP_STRING([--enable-debug], [compile extra debug messages]),
        [
         AC_MSG_RESULT([yes])
         AC_DEFINE([SIPSAK_PRINT_DBG], [1], [Enable debug messages])
@@ -99,7 +99,7 @@ AC_DEFUN([CHECK_PROG_DISTCC],
 [
     AC_MSG_CHECKING([whether to use distcc])
     AC_ARG_ENABLE([distcc],
-        AC_HELP_STRING([--enable-distcc], [compile in parallel with distcc]),
+        AS_HELP_STRING([--enable-distcc], [compile in parallel with distcc]),
         [
           AC_MSG_RESULT([yes])
           AC_CHECK_PROG([DISTCC], [distcc])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -134,7 +134,7 @@ AC_DEFUN([SIPSAK_GCC_STACK_PROTECT_CC],[
     AC_MSG_CHECKING([whether ${CC} accepts -fstack-protector])
     ssp_old_cflags="$CFLAGS"
     CFLAGS="$CFLAGS -fstack-protector"
-    AC_TRY_COMPILE(,,, ssp_cc=no)
+    AC_COMPILE_IFELSE(,,, ssp_cc=no)
     echo $ssp_cc
     if test "X$ssp_cc" = "Xno"; then
       CFLAGS="$ssp_old_cflags"

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -95,58 +95,6 @@ AC_DEFUN([SIPSAK_DBG_PRINT],
        ])
 ])
 
-AC_DEFUN([CHECK_LIB_RULI],
-[
-	AC_MSG_CHECKING([for ruli.h])
-
-	ruli_incdir=NONE
-	ruli_libdir=NONE
-	ruli_incdirs="/usr/include /usr/local/include /sw/include /opt/include /opt/local/include"
-	ruli_libdirs="/usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib /sw/lib /opt/lib /opt/local/lib"
-	ruli_libexten=".so .dylib .a"
-
-	for dir in $ruli_incdirs; do
-		try="$dir/ruli.h"
-		if test -f $try; then
-			ruli_incdir=$dir;
-			break;
-		fi
-	done
-
-	if test "$ruli_incdir" = "NONE"; then
-		AC_MSG_RESULT([not found])
-	else
-		AC_MSG_RESULT([found at $ruli_incdir])
-
-		AC_MSG_CHECKING([for libruli])
-
-		for dir in $ruli_libdirs; do
-			for extension in $ruli_libexten; do
-				try="$dir/libruli$extension"
-				if test -f $try; then
-					ruli_libdir=$dir;
-					break;
-				fi
-			done
-			if test "$ruli_libdir" != "NONE"; then
-				break;
-			fi
-		done
-
-		if test "$ruli_libdir" = "NONE"; then
-			AC_MSG_RESULT([not found])
-		else
-			AC_MSG_RESULT([found at $ruli_libdir])
-		fi
-
-		AC_CHECK_LIB(ruli, ruli_sync_query,
-		  AC_DEFINE([HAVE_RULI_H], [1], [Has ruli.h])
-		  LIBS="$LIBS -L$ruli_libdir -lruli"
-		  CFLAGS="$CFLAGS -I$ruli_incdir"
-		)
-	fi
-])
-
 AC_DEFUN([CHECK_PROG_DISTCC],
 [
     AC_MSG_CHECKING([for distcc])

--- a/configure.ac
+++ b/configure.ac
@@ -59,29 +59,23 @@ PKG_CHECK_MODULES([CHECK], [check >= 0.9.3], [
   ], []
 )
 
-
 PKG_CHECK_MODULES([GNUTLS], [gnutls >= 1.0.0], [
     AC_DEFINE([HAVE_GNUTLS], [1], [Has gnutls])
     LIBS="${LIBS} ${GNUTLS_LIBS}"
     CFLAGS="${CFLAGS} ${GNUTLS_CFLAGS}"
-  ], []
-)
+], [
+    AC_CHECK_HEADERS([openssl/md5.h], [
+      AC_SEARCH_LIBS([MD5_Init], [crypto], [
+        AC_DEFINE([HAVE_CRYPTO_WITH_MD5], [1], [The crypto lib has MD5 functions])
+      ])
+    ])
 
-if test "X$LIBGNUTLS_LIBS" = "X";then
-  AC_CHECK_HEADERS([openssl/md5.h],
-    AC_CHECK_LIB(crypto, MD5_Init,
-    AC_DEFINE([HAVE_CRYPTO_WITH_MD5], [1], [The crypto lib has MD5 functions])
-      LIBS="$LIBS -lcrypto"
-    )
-  )
-fi
-
-AC_CHECK_HEADERS([openssl/sha.h],
-  AC_CHECK_LIB(crypto, SHA1_Init,
-    AC_DEFINE([HAVE_CRYPTO_WITH_SHA1], [1], [The crpyto lib has SHA1 functions])
-    LIBS="$LIBS -lcrypto"
-  )
-)
+    AC_CHECK_HEADERS([openssl/sha.h], [
+      AC_SEARCH_LIBS([SHA1_Init], [crypto], [
+        AC_DEFINE([HAVE_CRYPTO_WITH_SHA1], [1], [The crpyto lib has SHA1 functions])
+      ])
+    ])
+])
 
 PKG_CHECK_MODULES([CARES], [libcares], [
   AC_DEFINE([HAVE_CARES_H], [1], [Has cares.h])

--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,6 @@ AC_FUNC_MALLOC
 AC_FUNC_SELECT_ARGTYPES
 AC_CHECK_FUNCS([getchar gethostbyname gethostname getopt getpid gettimeofday memset ntohs regcomp select socket strchr strcmp strstr strtol uname],,[AC_MSG_ERROR([missing required function (see above)])])
 AC_CHECK_FUNCS([calloc getdomainname getopt_long inet_ntop strncasecmp strcasestr syslog])
-PKG_PROG_PKG_CONFIG()
 
 # Check if the check unit test framework is available
 PKG_CHECK_MODULES([CHECK], [check >= 0.9.3], [

--- a/configure.ac
+++ b/configure.ac
@@ -89,7 +89,11 @@ PKG_CHECK_MODULES([CARES], [libcares], [
   CFLAGS="$CFLAGS $CARES_CFLAGS"
   AC_CHECK_HEADERS([arpa/nameser.h])
 ], [
-  CHECK_LIB_RULI
+  AC_CHECK_HEADERS([ruli.h], [
+    AC_SEARCH_LIBS([ruli_sync_query], [ruli], [
+      AC_DEFINE([HAVE_RULI_H], [1], [Has ruli.h])
+    ])
+  ])
 ])
 
 # FIXME: this has to replaced with a real check

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ(2.59)
 AC_INIT([sipsak],[0.9.7pre],[nils@sipsak.org])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 AM_MAINTAINER_MODE
 AC_CONFIG_SRCDIR([sipsak.c])
 AC_CONFIG_HEADER([config.h])


### PR DESCRIPTION
Update the build system to use modern macros instead of deprecated or ad-hoc manual code. Use new automake options to quiesce a warning. And fix some other issues.