### PR TITLE
Use automake subdir-objects option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Autotools
 *~
 .deps/
+.dirstamp
 INSTALL
 Makefile
 Makefile.in

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ(2.59)
 AC_INIT([sipsak],[0.9.7pre],[nils@sipsak.org])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 AM_MAINTAINER_MODE
 AC_CONFIG_SRCDIR([sipsak.c])
 AC_CONFIG_HEADER([config.h])

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,6 +2,6 @@ TESTS = check_helper
 
 check_PROGRAMS = check_helper
 
-check_helper_SOURCES = check_helper.c $(top_srcdir)/helper.h $(top_srcdir)/helper.c $(top_srcdir)/exit_code.h $(top_srcdir)/exit_code.c
+check_helper_SOURCES = check_helper.c ../helper.h ../helper.c ../exit_code.h ../exit_code.c
 check_helper_CFLAGS = @CHECK_CFLAGS@ -DRUNNING_CHECK
 check_helper_LDADD = @CHECK_LIBS@


### PR DESCRIPTION
Newer automake complain whenever there are subdirectories compiling code
from other directories. With this option we make sure the objects are
stored on the current build directory and do not interfere with the ones
they are coming from.