### PR TITLE
Remove unnecessary call to PKG_PROG_PKG_CONFIG

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,6 @@ AC_FUNC_MALLOC
 AC_FUNC_SELECT_ARGTYPES
 AC_CHECK_FUNCS([getchar gethostbyname gethostname getopt getpid gettimeofday memset ntohs regcomp select socket strchr strcmp strstr strtol uname],,[AC_MSG_ERROR([missing required function (see above)])])
 AC_CHECK_FUNCS([calloc getdomainname getopt_long inet_ntop strncasecmp strcasestr syslog])
-PKG_PROG_PKG_CONFIG()
 
 # Check if the check unit test framework is available
 PKG_CHECK_MODULES([CHECK], [check >= 0.9.3], [


### PR DESCRIPTION
This is only needed if the calls to PKG_CHECK_MODULES are behind
conditionals. Otherwise that macro already AC_REQUIREs the other.
