### PR TITLE
Fix stack-protector configure check

### DIFF
--- a/m4/acinclude.m4
+++ b/m4/acinclude.m4
@@ -198,7 +198,7 @@ AC_DEFUN([SIPSAK_GCC_STACK_PROTECT_CC],[
     AC_MSG_CHECKING([whether ${CC} accepts -fstack-protector])
     ssp_old_cflags="$CFLAGS"
     CFLAGS="$CFLAGS -fstack-protector"
-    AC_COMPILE_IFELSE(,,, ssp_cc=no)
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])], [], [], [ssp_cc=no])
     AC_MSG_RESULT([$ssp_cc])
     if test "X$ssp_cc" = "Xno"; then
       CFLAGS="$ssp_old_cflags"


### PR DESCRIPTION
We need to provide a source, otherwise the compilation will fail. Update
the call to use proper quoting.

Fixes #21.