### PR TITLE
Use standard autotools checks for distcc

### DIFF
--- a/m4/acinclude.m4
+++ b/m4/acinclude.m4
@@ -149,24 +149,12 @@ AC_DEFUN([CHECK_LIB_RULI],
 
 AC_DEFUN([CHECK_PROG_DISTCC],
 [
-    AC_MSG_CHECKING([for distcc])
+    AC_MSG_CHECKING([whether to use distcc])
     AC_ARG_ENABLE([distcc],
         AC_HELP_STRING([--enable-distcc], [compile in parallel with distcc]),
         [
-			distcc_dirs="/ /usr /usr/local /usr/local/gnu /usr/gnu /opt /opt/local"
-            for dir in $distcc_dirs; do
-                if test -x "$dir/bin/distcc"; then
-                    found_distcc=yes;
-                    DISTCC="$dir/bin/distcc"
-                    break;
-                fi
-            done
-            if test x_$found_distcc != x_yes; then
-                AC_MSG_ERROR([not found])
-            else
-                AC_MSG_RESULT([yes])
-                AC_SUBST([DISTCC])
-            fi
+          AC_MSG_RESULT([yes])
+          AC_CHECK_PROG([DISTCC], [distcc])
         ],
         [ AC_MSG_RESULT([not requested])
         ])


### PR DESCRIPTION
Use AC_CHECK_PROG instead of an ad-hoc list of directories and manual
checks.
