### PR TITLE
x-option for constant monitoring

### DIFF
--- a/sipsak.1
+++ b/sipsak.1
@@ -5,7 +5,7 @@
 .SH NAME
 sipsak \- a utility for various tests on sip servers and user agents
 .SH SYNOPSIS
-.B sipsak [-dFGhiILnNMRSTUVvwz] [-a
+.B sipsak [-dFGhiILnNMRSTUVvwzX] [-a
 .I PASSWORD
 .B ] [-b
 .I NUMBER 
@@ -108,6 +108,10 @@ parser.
 Stress mode for SIP servers.
 .B sipsak 
 keeps sending requests to a SIP server at high pace.
+. IP "- monitor mode (-X)"
+Monitoring mode for SIP servers.
+.B sipsak
+keeps sending messages as long as the server keeps responding.
 
 .PP
 If libruli (http://www.nongnu.org/ruli/) or c-ares 
@@ -525,6 +529,12 @@ success was above the given number.
 .IP "-x, --expires NUMBER"
 Sets the value of the Expires header to the given number.
 
+.IP "-X, --monitor-mode"
+Activates the monitoring mode.
+.B sipsak
+keeps sending messages as long as the target keeps responding. Useful to find
+out unresponsive destination.
+
 .IP "-z, --remove-bindings"
 Activates the randomly removing of old bindings in the usrloc mode. How many 
 per cent of the bindings will be removed, is determined by the 
@@ -536,6 +546,7 @@ Sets the amount of milliseconds for the SIP timer T1. It determines the
 length of the gaps between two retransmissions of a request on a unreliable
 transport. Default value is 500 if not changed via the configure option
 --enable-timeout.
+
 
 .SH RETURN VALUES
 The return value 0 means that a 200 was received. 1 means something else 
@@ -567,6 +578,9 @@ inserts forwarding from work to home for one hour.
 .IP "sipsak -f bye.sip -g '!FTAG!345.af23!TTAG!1208.12!' -s sip:myproxy"
 reads the file bye.sip, replaces $FTAG$ with 345.af23 and $TTAG$ with
 1208.12 and finally send this message to myproxy
+.IP "sipsak -s sip:foo@bar.com -X -Z 250 -D 5"
+pings in a loop up to five times a SIP URI in 250 ms interval until an
+erroc occurs.
 
 .SH LIMITATIONS / NOT IMPLEMENTED
 Many servers may decide NOT to include SIP "Warning" header fields.

--- a/sipsak.h
+++ b/sipsak.h
@@ -293,6 +293,9 @@
 #define USRLOC_EXP_DEF 15
 #define FLOOD_METH "OPTIONS"
 
+
+#define OPTIONS_STRING "a:A:b:B:c:C:dD:e:E:f:Fg:GhH:iIj:J:k:K:l:Lm:MnNo:O:p:P:q:r:Rs:St:Tu:XUvVwW:x:z:Z:"
+
 #define SIPSAK_HASHLEN_MD5 16
 #define SIPSAK_HASHHEXLEN_MD5 2 * SIPSAK_HASHLEN_MD5
 #ifdef HAVE_OPENSSL_SHA1
@@ -328,6 +331,7 @@ int sleep_ms, processes, cseq_counter;
 int verbose, nameend, namebeg, expires_t, flood, warning_ext, invite, message;
 int maxforw, lport, rport, randtrash, trashchar, numeric, symmetric;
 int file_b, uri_b, trace, via_ins, usrloc, redirects, rand_rem, replace_b;
+int monitor_mode;
 int empty_contact, nagios_warn, fix_crlf, timing, outbound_proxy;
 int timer_t1, timer_t2, timer_final, sysl;
 char *username, *domainname, *password, *replace_str, *hostname, *contact_uri;


### PR DESCRIPTION
introduce new monitoring mode that keeps sipsak running until
failureThis new -X mode keeps sending messages until a failure occurs. A
negative answer is not considered a failure. This is helpful when you
want to monitor a SIP device and do not want to restart sipsak all over
again — it keeps running until the device fails. In this mode, the
RFC3261 retransmission timers are ignored — they are constant.

Use it like this: keep trying every 1/4 sec and return with a failure
if 5 retries are not sufficient:
sipsak -s sip:foo@bar.com -X -Z 250 -D 5

I know it is not a best practice but I did several unnecessary changes
too — the code was simply too widely nested and I had a too narrow
monitor — I hope that’s fine. If not I can submit just the minimum
necessary changes instead.