### PR TITLE
Fix MD5 auth calculation on many 64-bit systems.

### DIFF
--- a/md5global.h
+++ b/md5global.h
@@ -15,11 +15,13 @@ The following makes PROTOTYPES default to 0 if it has not already
 /* POINTER defines a generic pointer type */
 typedef unsigned char *POINTER;
 
-/* UINT2 defines a two byte word */
-typedef unsigned short int UINT2;
-
+#ifdef HAVE_STDINT_H
+# include <stdint.h>
+typedef uint32_t UINT4;
+#else
 /* UINT4 defines a four byte word */
 typedef unsigned long int UINT4;
+#endif
 
 /* PROTO_LIST is defined depending on how PROTOTYPES is defined above.
 If using PROTOTYPES, then PROTO_LIST returns the list, otherwise it


### PR DESCRIPTION
Unsigned long is very often 8 bytes, not 4. Use stdint.h if available.

Before: 403 on REGISTER
After: 200 like with the debian-supplied sipsak 0.9.6-2.1build1