### PR TITLE
Travis-ci:added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,19 @@ language: c
 os:
   - linux
   - osx
+arch:
+  - amd64
+  - ppc64le
 compiler:
   - clang
   - gcc
+matrix:
+   exclude:
+     - os: osx
+       arch: ppc64le
+     - os: linux
+       compiler: clang
+       arch: ppc64le
 sudo: false
 addons:
   apt:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch on behalf of IBM . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/sipsak/builds/208663264 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!