### PR TITLE
Respect priority field on SRV DNS records

### DIFF
--- a/src/helper.c
+++ b/src/helper.c
@@ -55,6 +55,7 @@
 # endif
  int caport;
  unsigned long caadr;
+ int capriority;
  char *ca_tmpname;
  ares_channel channel;
 
@@ -177,20 +178,25 @@ static const unsigned char *parse_rr(const unsigned char *aptr, const unsigned c
 	}
 	if (type == CARES_TYPE_SRV) {
 		free(name);
-		caport = DNS__16BIT(aptr + 4);
-		dbg("caport: %i\n", caport);
-		status = ares_expand_name(aptr + 6, abuf, alen, &name, &len);
-		if (status != ARES_SUCCESS) {
-			printf("error: failed to expand SRV name\n");
-			return NULL;
-		}
-		dbg("SRV name: %s\n", name);
-		if (is_ip(name)) {
-			caadr = inet_addr(name);
-			free(name);
-		}
-		else {
-			ca_tmpname = name;
+		int priority = DNS__16BIT(aptr);
+		dbg("Processing SRV record with priority %d\n", priority);
+		if (capriority == -1 || priority < capriority) {
+			capriority = priority;
+			caport = DNS__16BIT(aptr + 4);
+			dbg("caport: %i\n", caport);
+			status = ares_expand_name(aptr + 6, abuf, alen, &name, &len);
+			if (status != ARES_SUCCESS) {
+				printf("error: failed to expand SRV name\n");
+				return NULL;
+			}
+			dbg("SRV name: %s\n", name);
+			if (is_ip(name)) {
+				caadr = inet_addr(name);
+				free(name);
+			}
+			else {
+				ca_tmpname = name;
+			}
 		}
 	}
 	else if (type == CARES_TYPE_CNAME) {
@@ -299,17 +305,14 @@ static void cares_callback(void *arg, int status, int timeouts, unsigned char *a
 		return;
 	}
 
-	for (i = 0; i < ancount && caadr == 0 && aptr != NULL; i++) {
-		if (ca_tmpname == NULL)
-			aptr = parse_rr(aptr, abuf, alen);
-		else
-			aptr = skip_rr(aptr, abuf, alen);
+	for (i = 0; i < ancount && aptr != NULL; i++) {
+		aptr = parse_rr(aptr, abuf, alen);
 	}
 	if (caadr == 0 && aptr != NULL) {
 		for (i = 0; i < nscount && aptr != NULL; i++) {
 			aptr = skip_rr(aptr, abuf, alen);
 		}
-		for (i = 0; i < arcount && caadr == 0; i++) {
+		for (i = 0; i < arcount && aptr != NULL; i++) {
 			aptr = parse_rr(aptr, abuf, alen);
 		}
 	}
@@ -323,6 +326,7 @@ static inline unsigned long srv_ares(char *host, int *port, char *srv) {
 
 	caport = 0;
 	caadr = 0;
+	capriority = -1;
 	ca_tmpname = NULL;
 	dbg("starting ARES query\n");
 


### PR DESCRIPTION
Among various pending improvements, sipsak's TODO file has todo items for supporting priority/weight fields in SRV DNS records.

In my use of sipsak, I am having problems with sipsak being inconsistent in which SIP server it uses. There is a primary SIP server which I want it to use, but sometimes it uses a redundant backup SIP server instead. The redundancy/failover is implemented by returning SRV records for both SIP servers, with a lower (which really means higher) 'priority' value for the primary. Hence, I would love to add support for the priority field (at least).

This is about the least invasive patch I could make which implements support for SRV priority without changing the overall design of the DNS lookup code. However, since it makes `cares_callback` iterate through *all* records in a DNS reply, rather than stopping as soon as it has an IP address, this could impact other users. I would love to hear if the maintainer foresees any problems with this.

After reading the code in `helper.c`, it strongly appears to me that the DNS lookup code can leak memory in some cases, depending on which DNS records are present in a DNS reply and their order. It may be that the memory leaks do not normally occur if the DNS records are as expected. Is this a matter of concern? Perhaps you are not worried about it.

Do you strongly feel that support for both SRV priority and weight should be added at the same time? If so, it may call for a more extensive redesign of the current code. The current code uses a few global variables to hold its state, and updates these as it iterates over the received DNS records. However, if SRV weight is to be supported, I think we need to parse the data from the DNS records into another data structure and then process that data structure. This would add a bit more complexity, but I think the code would become more robust.