### PR TITLE
Dividing --sleep (ms) by 1000 to get sec value

### DIFF
--- a/src/shoot.c
+++ b/src/shoot.c
@@ -1029,7 +1029,7 @@ void shoot(char *buf, int buff_size, struct sipsak_options *options)
 			sleep_ms_s.tv_sec = rand_tmp / 1000;
 			sleep_ms_s.tv_nsec = (rand_tmp % 1000) * 1000;
 		} else if (options->sleep_ms != 0) {
-			sleep_ms_s.tv_sec = options->sleep_ms;
+			sleep_ms_s.tv_sec = options->sleep_ms / 1000;
 			sleep_ms_s.tv_nsec = (options->sleep_ms % 1000) * 1000000;
 		}
 		if (options->sleep_ms != 0) {


### PR DESCRIPTION
The value of the -o/--sleep param (in milliseconds) was copied without changes to the variable holding the seconds in the struct.
The correct conversion was present in 0.9.6 but was lost somewhere between 0.9.6 and 0.9.8.
The fix adds the division by 1000 again to get the seconds from the milliseconds.