### PR TITLE
[Outbound-Proxy] Use SRV Logic only if remote-port is not defined

### DIFF
--- a/src/sipsak.c
+++ b/src/sipsak.c
@@ -619,7 +619,7 @@ int main(int argc, char *argv[])
 						options.transport = SIP_UDP_TRANSPORT;
 				}
 				else {
-					if (!port) {
+					if (!port && !options.rport) {
 						options.address = getsrvadr(host, &options.rport, &tsp);
 						if (tsp != 0)
 							options.transport = tsp;


### PR DESCRIPTION
At this phase `SRV` logic is used if we don't pass a port in the `SIP URI` of `Outbound-Proxy` flag (`-p` flag). But, `SRV lookup` will be executed  even if we pass a remote port before (`-r` flag). And for my perspective, `SRV lookup` should be skipped, if we pass a specific remote port in the command.
The change added is not abusive, and seems to not break anything. If we want to continue use `SRV lookup`, it's enough to didn't provide `remote-port` flag, of pass it after `-p` flag.

Tested with multiple `transports`, and passing `IPs` and `hostnames`. Also with `port (in the -p flag)`, and with `remote-port` flag.

Thanks @nils-ohlmeier