### PR TITLE
use libgnutls-openssl for md5 if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,12 @@ PKG_CHECK_MODULES([GNUTLS], [gnutls >= 1.0.0], [
     HAVE_GNUTLS=1
     LIBS="${LIBS} ${GNUTLS_LIBS}"
     CFLAGS="${CFLAGS} ${GNUTLS_CFLAGS}"
+    AC_CHECK_HEADERS([gnutls/openssl.h], [
+      AC_SEARCH_LIBS([MD5_Init], [crypto], [
+        AC_DEFINE([HAVE_EXTERNAL_MD5], [1], [The crypto lib has MD5 functions])
+	LIBS="${LIBS} -lgnutls-openssl"
+      ])
+    ])
   ], [
     AC_CHECK_HEADERS([openssl/md5.h], [
       AC_SEARCH_LIBS([MD5_Init], [crypto], [

--- a/src/sipsak.h
+++ b/src/sipsak.h
@@ -75,6 +75,9 @@
 #  define WITH_TLS_TRANSP 1
 # endif
 # include <gnutls/gnutls.h>
+# ifdef HAVE_EXTERNAL_MD5
+#  include <gnutls/openssl.h>
+# endif
 #else
 # ifdef HAVE_OPENSSL_MD5_H
 #  ifdef HAVE_CRYPTO_WITH_MD5


### PR DESCRIPTION
vendor md5 is outdated and can't build with c23
use md5 provided by libgnutls-openssl if available

EDIT : abort, 2 tests with failures : check_auth / check_md5