### PR TITLE
Update to handle Content-Length header without space after colon

### DIFF
--- a/src/header_f.c
+++ b/src/header_f.c
@@ -245,8 +245,8 @@ void uri_replace(char *mes, char *uri)
 void set_cl(char* mes, int contentlen) {
 	char *cl, *cr, *backup;
 
-	if ((cl=STRCASESTR(mes, CON_LEN_STR)) == NULL &&
-		(cl=STRCASESTR(mes, CON_LEN_SHORT_STR)) == NULL) {
+	if ((cl=STRCASESTR(mes, CON_LEN_STR_SEARCH)) == NULL &&
+		(cl=STRCASESTR(mes, CON_LEN_SHORT_STR_SEARCH)) == NULL) {
 		printf("missing Content-Length in message\n");
 		return;
 	}
@@ -258,9 +258,12 @@ void set_cl(char* mes, int contentlen) {
 	backup=str_alloc(strlen(cr)+1);
 	strncpy(backup, cr, strlen(cr));
 	if (*cl == 'C')
-		cr=cl + CON_LEN_STR_LEN;
+		cr=cl + CON_LEN_STR_SEARCH_LEN;
 	else
-		cr=cl + 3;
+		cr=cl + CON_LEN_SHORT_STR_SEARCH_LEN;
+	/* skip optional whitespace after colon */
+	while (*cr == ' ')
+		cr++;
 	snprintf(cr, 6, "%i\r\n", contentlen);
 	cr=strchr(cr, '\n');
 	cr++;
@@ -277,18 +280,21 @@ void set_cl(char* mes, int contentlen) {
 int get_cl(char* mes) {
 	char *cl;
 
-	if ((cl=STRCASESTR(mes, CON_LEN_STR)) == NULL &&
-		(cl=STRCASESTR(mes, CON_LEN_SHORT_STR)) == NULL) {
+	if ((cl=STRCASESTR(mes, CON_LEN_STR_SEARCH)) == NULL &&
+		(cl=STRCASESTR(mes, CON_LEN_SHORT_STR_SEARCH)) == NULL) {
 		if (verbose > 1)
 			printf("missing Content-Length in message\n");
 		return -1;
 	}
 	if (*cl == '\n') {
-		cl+=3;
+		cl+=CON_LEN_SHORT_STR_SEARCH_LEN;
 	}
 	else {
-		cl+=15;
+		cl+=CON_LEN_STR_SEARCH_LEN;
 	}
+	/* skip optional whitespace after colon */
+	while (*cl == ' ')
+		cl++;
 	return str_to_int(1, cl);
 }
 

--- a/src/sip_strings.h
+++ b/src/sip_strings.h
@@ -91,6 +91,10 @@
 #define CON_LEN_STR_LEN (sizeof(CON_LEN_STR) - 1)
 #define CON_LEN_SHORT_STR "\nl: "
 #define CON_LEN_SHORT_STR_LEN (sizeof(CON_LEN_SHORT_STR) - 1)
+#define CON_LEN_STR_SEARCH "Content-Length:"
+#define CON_LEN_STR_SEARCH_LEN (sizeof(CON_LEN_STR_SEARCH) - 1)
+#define CON_LEN_SHORT_STR_SEARCH "\nl:"
+#define CON_LEN_SHORT_STR_SEARCH_LEN (sizeof(CON_LEN_SHORT_STR_SEARCH) - 1)
 
 #define RR_STR "Record-Route: "
 #define RR_STR_LEN (sizeof(RR_STR) -  1)


### PR DESCRIPTION
PR for Issue https://github.com/nils-ohlmeier/sipsak/issues/101

Change to handle the Content-Length header when header does not have a space after the colon ":" e.g. "\nContent-Length:0" 

Created new constants for use when searching for the headers, keeping the existing ones for the other uses to maintain use fo the preferred form of the headers and keep existing behavior.

If this is an acceptable way to address this issue then the other headers could be handled the same.

Built and tested locally, resolved the issue when using TCP.